### PR TITLE
Fixed filters form from losing focus after typing

### DIFF
--- a/src/components/UI/Input/Input.js
+++ b/src/components/UI/Input/Input.js
@@ -41,7 +41,7 @@ const input = (props) => {
                     value={props.value}
                     onChange={props.changed}>
                     {props.options.map(option => (
-                        <option key={option.key} value={option.value}>
+                        <option key={`${props.keyPrefix}${option.key}`} value={option.value}>
                             {option.value}
                         </option>
                     ))}

--- a/src/containers/Filters/Filters.js
+++ b/src/containers/Filters/Filters.js
@@ -483,6 +483,7 @@ class Filters extends Component {
                     {elementsArray.map(controlElement => (
                         <Input 
                             key={`${keyPrefix}${controlElement.id}`}
+                            keyPrefix={keyPrefix}
                             elementDisplay={controlElement.config.elementDisplay}
                             elementType={controlElement.config.elementType}
                             elementConfig={controlElement.config.elementConfig}
@@ -534,7 +535,7 @@ class Filters extends Component {
                 }
 
                 filtersFormArray.push(
-                    <Auxiliary key={uuid.v4()}>
+                    <Auxiliary key={filterElementsArray[0].filtersId}>
                         <Auxiliary>
                             {controlsForm(filterElementsArray, filterElementsArray[0].filtersId, this.props.didGetFilters)}
                         </Auxiliary>


### PR DESCRIPTION
- Fixed a bug where the filters form lost focus shortly after typing
- This was because the generated uuids that were used as keys for the
filter forms do not persist when the form re-renders, so a new uuid
is generated and this makes the form input lose focus
- The fix is to set the key to the `filterId`s
- Also added the `filterId`s to the keys for the subreddit options to
resolve a React console warning