### PR TITLE
Made the filters form feel more intuitive

### DIFF
--- a/src/components/UI/Button/Button.js
+++ b/src/components/UI/Button/Button.js
@@ -5,7 +5,7 @@ import classes from './Button.css';
 const button = (props) => (
     <button
         disabled={props.disabled}
-        className={[classes.Button, classes[props.buttonType]].join(' ')}
+        className={[classes.Button, classes[props.buttonType], props.classes].join(' ')}
         onClick={props.clicked}>{props.children}</button>
 );
 

--- a/src/components/UI/Input/Input.css
+++ b/src/components/UI/Input/Input.css
@@ -1,16 +1,4 @@
 .Input {
-    width: 100%;
-    padding: 10px;
-    box-sizing: border-box;
-}
-
-.Label {
-    font-weight: bold;
-    display: block;
-    margin-bottom: 8px;
-}
-
-.BlockInputElement {
     margin: 0 auto;
     margin-left: auto;
     margin-right: auto;
@@ -25,29 +13,50 @@
     box-sizing: border-box;
 }
 
+::-webkit-input-placeholder {
+    color: #c8c8c8;
+ }
+
+.Label {
+    font-weight: bold;
+    display: block;
+    margin-bottom: 8px;
+}
+
 .InputElement:focus {
     outline: none;
     background-color: #ccc;
 }
 
-.RowInputElement {
-    outline: none;
-    border: 1px solid #ccc;
-    background-color: white;
-    font: inherit;
-    padding: 6px 10px;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-    display: flex;
-    flex-flow: row;
-    align-items: center;
-    height: 100%;
-    width: 100%;
-    box-sizing: border-box;
-}
-
 .Invalid {
     border: 1px solid red;
     background-color: salmon;
+}
+
+.RowNormal {
+    float: left;
+    outline: none;
+    font: inherit;
+    margin: 0;
+    list-style: none;
+    white-space: nowrap;
+    flex-flow: row;
+    align-items: center;
+    height: 100%;
+    min-width: 200px;
+    box-sizing: border-box;
+}
+
+.RowSmall {
+    float: left;
+    outline: none;
+    font: inherit;
+    margin: 0;
+    list-style: none;
+    white-space: nowrap;
+    flex-flow: row;
+    align-items: center;
+    height: 100%;
+    width: 100px;
+    box-sizing: border-box;
 }

--- a/src/components/UI/Input/Input.js
+++ b/src/components/UI/Input/Input.js
@@ -6,10 +6,13 @@ const input = (props) => {
     let inputClasses = [];
     switch (props.elementDisplay) {
         case('block'):
-            inputClasses = [classes.BlockInputElement];
+            inputClasses = [classes.Input];
             break;
-        case('row'):
-            inputClasses = [classes.RowInputElement];
+        case('normal'):
+            inputClasses = [classes.RowNormal];
+            break;
+        case('small'):
+            inputClasses = [classes.RowSmall];
             break;
         default:
             inputClasses = [];
@@ -56,7 +59,7 @@ const input = (props) => {
     }
 
     return (
-        <div className={classes.Input}>
+        <div>
             <label className={classes.Label}>{props.label}</label>
             {inputElement}
         </div>

--- a/src/containers/Filters/Filters.css
+++ b/src/containers/Filters/Filters.css
@@ -7,3 +7,7 @@
     padding: 10px;
     box-sizing: border-box;
 }
+
+.FloatRight {
+    float: right;
+}

--- a/src/containers/Filters/Filters.js
+++ b/src/containers/Filters/Filters.js
@@ -20,10 +20,10 @@ class Filters extends Component {
 
     initialControlValues = {
         subreddit: {
-            elementDisplay: 'row',
+            elementDisplay: 'normal',
             elementType: 'select',
             elementConfig: {
-                placeholder: ''
+                placeholder: '<subreddit>'
             },
             value: '',
             validation: {
@@ -35,11 +35,11 @@ class Filters extends Component {
             touched: true
         },
         minScore: {
-            elementDisplay: 'row',
+            elementDisplay: 'small',
             elementType: 'input',
             elementConfig: {
                 type: 'number',
-                placeholder: ''
+                placeholder: '<min score>'
             },
             value: '',
             validation: {
@@ -53,11 +53,11 @@ class Filters extends Component {
             touched: false
         },
         hideByDomain: {
-            elementDisplay: 'row',
+            elementDisplay: 'normal',
             elementType: 'input',
             elementConfig: {
                 type: 'text',
-                placeholder: ''
+                placeholder: '<hide by domain>'
             },
             value: '',
             validation: {
@@ -69,11 +69,11 @@ class Filters extends Component {
             touched: false
         },
         hideByKeyword: {
-            elementDisplay: 'row',
+            elementDisplay: 'normal',
             elementType: 'input',
             elementConfig: {
                 type: 'text',
-                placeholder: ''
+                placeholder: '<hide by keyword>'
             },
             value: '',
             validation: {
@@ -85,11 +85,11 @@ class Filters extends Component {
             touched: false
         },
         showByDomain: {
-            elementDisplay: 'row',
+            elementDisplay: 'normal',
             elementType: 'input',
             elementConfig: {
                 type: 'text',
-                placeholder: ''
+                placeholder: '<only show from domain>'
             },
             value: '',
             validation: {
@@ -101,11 +101,11 @@ class Filters extends Component {
             touched: false
         },
         showByKeyword: {
-            elementDisplay: 'row',
+            elementDisplay: 'normal',
             elementType: 'input',
             elementConfig: {
                 type: 'text',
-                placeholder: ''
+                placeholder: '<only show by keyword>'
             },
             value: '',
             validation: {
@@ -121,10 +121,10 @@ class Filters extends Component {
     state = {
         controls: {
             subreddit: {
-                elementDisplay: 'row',
+                elementDisplay: 'normal',
                 elementType: 'select',
                 elementConfig: {
-                    placeholder: ''
+                    placeholder: '<subreddit>'
                 },
                 value: '',
                 validation: {
@@ -136,11 +136,11 @@ class Filters extends Component {
                 touched: true
             },
             minScore: {
-                elementDisplay: 'row',
+                elementDisplay: 'small',
                 elementType: 'input',
                 elementConfig: {
                     type: 'number',
-                    placeholder: ''
+                    placeholder: '<min score>'
                 },
                 value: '',
                 validation: {
@@ -154,11 +154,11 @@ class Filters extends Component {
                 touched: false
             },
             hideByDomain: {
-                elementDisplay: 'row',
+                elementDisplay: 'normal',
                 elementType: 'input',
                 elementConfig: {
                     type: 'text',
-                    placeholder: ''
+                    placeholder: '<hide by domain>'
                 },
                 value: '',
                 validation: {
@@ -170,11 +170,11 @@ class Filters extends Component {
                 touched: false
             },
             hideByKeyword: {
-                elementDisplay: 'row',
+                elementDisplay: 'normal',
                 elementType: 'input',
                 elementConfig: {
                     type: 'text',
-                    placeholder: ''
+                    placeholder: '<hide by keyword>'
                 },
                 value: '',
                 validation: {
@@ -186,11 +186,11 @@ class Filters extends Component {
                 touched: false
             },
             showByDomain: {
-                elementDisplay: 'row',
+                elementDisplay: 'normal',
                 elementType: 'input',
                 elementConfig: {
                     type: 'text',
-                    placeholder: ''
+                    placeholder: '<only show from domain>'
                 },
                 value: '',
                 validation: {
@@ -202,11 +202,11 @@ class Filters extends Component {
                 touched: false
             },
             showByKeyword: {
-                elementDisplay: 'row',
+                elementDisplay: 'normal',
                 elementType: 'input',
                 elementConfig: {
                     type: 'text',
-                    placeholder: ''
+                    placeholder: '<only show by keyword>'
                 },
                 value: '',
                 validation: {
@@ -568,11 +568,13 @@ class Filters extends Component {
             <Auxiliary className={classes.Filters}>
                 {filtersRedirect}
                 {errorMessage}
-                {createFiltersForm}
+                {createFiltersForm}                    
+                <hr />
                 {filtersForm}
                 <Button 
                     key='search' 
                     buttonType="Successful" 
+                    classes={[classes.FloatRight].join(' ')}
                     clicked={(event) => this.searchHandler(event)}>Save and Search</Button>
             </Auxiliary>
         );

--- a/src/hoc/Layout/Layout.css
+++ b/src/hoc/Layout/Layout.css
@@ -1,3 +1,3 @@
 .Content {
-    margin-top: 20px;
+    margin: 45px 10px;
 }


### PR DESCRIPTION
- Modified `<Button>` component so that class props can be passed
- Made the `Save and Search` filter button float right
- Made `<Input>` placeholder text color lighter
- Made the `Block` css class the default `<Input>` class
- Separated the `Row` css class into normal size and small size classes
- Reflected these changes in the `<Input>` component logic and the filters state
- Added placeholder text for the filter inputs