### PR TITLE
Fixed nextResults functions not called when results are empty

### DIFF
--- a/src/containers/Results/BestResults.js
+++ b/src/containers/Results/BestResults.js
@@ -46,7 +46,7 @@ class Results extends Component {
             switch(this.props.error.status) {
                 case 400:
                 case 401:
-                    errorMessage = `Error: Bad request. Could not get results.`;
+                    errorMessage = `Sorry, no results found. Try adjusting your filters.`;
                     break;
                 case 404:
                     errorMessage = `Error: No results found. Make sure you set your filters.`;

--- a/src/containers/Results/HotResults.js
+++ b/src/containers/Results/HotResults.js
@@ -46,7 +46,7 @@ class Results extends Component {
             switch(this.props.error.status) {
                 case 400:
                 case 401:
-                    errorMessage = `Error: Bad request. Could not get results.`;
+                    errorMessage = `Sorry, no results found. Try adjusting your filters.`;
                     break;
                 case 404:
                     errorMessage = `Error: No results found. Make sure you set your filters.`;

--- a/src/containers/Results/NewResults.js
+++ b/src/containers/Results/NewResults.js
@@ -46,7 +46,7 @@ class Results extends Component {
             switch(this.props.error.status) {
                 case 400:
                 case 401:
-                    errorMessage = `Error: Bad request. Could not get results.`;
+                    errorMessage = `Sorry, no results found. Try adjusting your filters.`;
                     break;
                 case 404:
                     errorMessage = `Error: No results found. Make sure you set your filters.`;

--- a/src/containers/Results/TopResults.js
+++ b/src/containers/Results/TopResults.js
@@ -46,7 +46,7 @@ class Results extends Component {
             switch(this.props.error.status) {
                 case 400:
                 case 401:
-                    errorMessage = `Error: Bad request. Could not get results.`;
+                    errorMessage = `Sorry, no results found. Try adjusting your filters.`;
                     break;
                 case 404:
                     errorMessage = `Error: No results found. Make sure you set your filters.`;

--- a/src/store/actions/results/bestResults.js
+++ b/src/store/actions/results/bestResults.js
@@ -61,22 +61,26 @@ export const bestGetResults = () => {
             const resultsResponse = response.data.results;
             const nextUri = response.data.nextUri;
             const afterId = response.data.afterId;
-            const results = [];
-            for (let index in resultsResponse) {
-                let result = {};
-                result.id = resultsResponse[index].resultsId;
-                result.subreddit = resultsResponse[index].subreddit;
-                result.url = resultsResponse[index].url;
-                result.title = resultsResponse[index].title;
-                result.permalink = resultsResponse[index].permalink;
-                result.score = resultsResponse[index].score;
-                result.createdUtc = resultsResponse[index].createdUtc;
-                result.domain = resultsResponse[index].domain;
-                result.comments = resultsResponse[index].comments;
-                results.push(result);
-            }
+            if (!resultsResponse.length) {
+                dispatch(bestGetNextResults(resultsResponse, nextUri, afterId));
+            } else {
+                const results = [];
+                for (let index in resultsResponse) {
+                    let result = {};
+                    result.id = resultsResponse[index].resultsId;
+                    result.subreddit = resultsResponse[index].subreddit;
+                    result.url = resultsResponse[index].url;
+                    result.title = resultsResponse[index].title;
+                    result.permalink = resultsResponse[index].permalink;
+                    result.score = resultsResponse[index].score;
+                    result.createdUtc = resultsResponse[index].createdUtc;
+                    result.domain = resultsResponse[index].domain;
+                    result.comments = resultsResponse[index].comments;
+                    results.push(result);
+                }
 
-            dispatch(resultsGetResultsSuccess(nextUri, afterId, results));
+                dispatch(resultsGetResultsSuccess(nextUri, afterId, results));
+            }
         })
         .catch(error => {
             dispatch(resultsGetResultsFail(error.response));
@@ -102,24 +106,28 @@ export const bestGetNextResults = (results, nextUri, afterId) => {
         const uri = `/results/fetch/next`;
         axios.post(uri, postBody, {headers})
         .then(response => {
-            const resultsResponse = response.data.results;
-            const updatedResults = cloneDeep(results);
-            for (let index in resultsResponse) {
-                let result = {};
-                result.id = resultsResponse[index].resultsId;
-                result.subreddit = resultsResponse[index].subreddit;
-                result.url = resultsResponse[index].url;
-                result.title = resultsResponse[index].title;
-                result.permalink = resultsResponse[index].permalink;
-                result.score = resultsResponse[index].score;
-                result.createdUtc = resultsResponse[index].createdUtc;
-                result.domain = resultsResponse[index].domain;
-                result.comments = resultsResponse[index].comments;
-                updatedResults.push(result);
-            }
+            const newAfterId = response.data.afterId;
+            if (!response.data.results.length) {
+                dispatch(bestGetNextResults(results, nextUri, newAfterId));
+            } else {
+                const resultsResponse = response.data.results;
+                const updatedResults = cloneDeep(results);
+                for (let index in resultsResponse) {
+                    let result = {};
+                    result.id = resultsResponse[index].resultsId;
+                    result.subreddit = resultsResponse[index].subreddit;
+                    result.url = resultsResponse[index].url;
+                    result.title = resultsResponse[index].title;
+                    result.permalink = resultsResponse[index].permalink;
+                    result.score = resultsResponse[index].score;
+                    result.createdUtc = resultsResponse[index].createdUtc;
+                    result.domain = resultsResponse[index].domain;
+                    result.comments = resultsResponse[index].comments;
+                    updatedResults.push(result);
+                }
 
-            const afterId = response.data.afterId;
-            dispatch(resultsGetNextResultsSuccess(afterId, updatedResults));
+                dispatch(resultsGetNextResultsSuccess(newAfterId, updatedResults));
+            }
         })
         .catch(error => {
             dispatch(resultsGetNextResultsFail(error.response));

--- a/src/store/actions/results/hotResults.js
+++ b/src/store/actions/results/hotResults.js
@@ -61,22 +61,26 @@ export const hotGetResults = () => {
             const resultsResponse = response.data.results;
             const nextUri = response.data.nextUri;
             const afterId = response.data.afterId;
-            const results = [];
-            for (let index in resultsResponse) {
-                let result = {};
-                result.id = resultsResponse[index].resultsId;
-                result.subreddit = resultsResponse[index].subreddit;
-                result.url = resultsResponse[index].url;
-                result.title = resultsResponse[index].title;
-                result.permalink = resultsResponse[index].permalink;
-                result.score = resultsResponse[index].score;
-                result.createdUtc = resultsResponse[index].createdUtc;
-                result.domain = resultsResponse[index].domain;
-                result.comments = resultsResponse[index].comments;
-                results.push(result);
-            }
+            if (!resultsResponse.length) {
+                dispatch(hotGetNextResults(resultsResponse, nextUri, afterId));
+            } else {
+                const results = [];
+                for (let index in resultsResponse) {
+                    let result = {};
+                    result.id = resultsResponse[index].resultsId;
+                    result.subreddit = resultsResponse[index].subreddit;
+                    result.url = resultsResponse[index].url;
+                    result.title = resultsResponse[index].title;
+                    result.permalink = resultsResponse[index].permalink;
+                    result.score = resultsResponse[index].score;
+                    result.createdUtc = resultsResponse[index].createdUtc;
+                    result.domain = resultsResponse[index].domain;
+                    result.comments = resultsResponse[index].comments;
+                    results.push(result);
+                }
 
-            dispatch(resultsGetResultsSuccess(nextUri, afterId, results));
+                dispatch(resultsGetResultsSuccess(nextUri, afterId, results));
+            }
         })
         .catch(error => {
             dispatch(resultsGetResultsFail(error.response));
@@ -102,24 +106,28 @@ export const hotGetNextResults = (results, nextUri, afterId) => {
         const uri = `/results/fetch/next`;
         axios.post(uri, postBody, {headers})
         .then(response => {
-            const resultsResponse = response.data.results;
-            const updatedResults = cloneDeep(results);
-            for (let index in resultsResponse) {
-                let result = {};
-                result.id = resultsResponse[index].resultsId;
-                result.subreddit = resultsResponse[index].subreddit;
-                result.url = resultsResponse[index].url;
-                result.title = resultsResponse[index].title;
-                result.permalink = resultsResponse[index].permalink;
-                result.score = resultsResponse[index].score;
-                result.createdUtc = resultsResponse[index].createdUtc;
-                result.domain = resultsResponse[index].domain;
-                result.comments = resultsResponse[index].comments;
-                updatedResults.push(result);
-            }
+            const newAfterId = response.data.afterId;
+            if (!response.data.results.length) {
+                dispatch(hotGetNextResults(results, nextUri, newAfterId));
+            } else {
+                const resultsResponse = response.data.results;
+                const updatedResults = cloneDeep(results);
+                for (let index in resultsResponse) {
+                    let result = {};
+                    result.id = resultsResponse[index].resultsId;
+                    result.subreddit = resultsResponse[index].subreddit;
+                    result.url = resultsResponse[index].url;
+                    result.title = resultsResponse[index].title;
+                    result.permalink = resultsResponse[index].permalink;
+                    result.score = resultsResponse[index].score;
+                    result.createdUtc = resultsResponse[index].createdUtc;
+                    result.domain = resultsResponse[index].domain;
+                    result.comments = resultsResponse[index].comments;
+                    updatedResults.push(result);
+                }
 
-            const afterId = response.data.afterId;
-            dispatch(resultsGetNextResultsSuccess(afterId, updatedResults));
+                dispatch(resultsGetNextResultsSuccess(newAfterId, updatedResults));
+            }
         })
         .catch(error => {
             dispatch(resultsGetNextResultsFail(error.response));

--- a/src/store/actions/results/newResults.js
+++ b/src/store/actions/results/newResults.js
@@ -61,22 +61,26 @@ export const newGetResults = () => {
             const resultsResponse = response.data.results;
             const nextUri = response.data.nextUri;
             const afterId = response.data.afterId;
-            const results = [];
-            for (let index in resultsResponse) {
-                let result = {};
-                result.id = resultsResponse[index].resultsId;
-                result.subreddit = resultsResponse[index].subreddit;
-                result.url = resultsResponse[index].url;
-                result.title = resultsResponse[index].title;
-                result.permalink = resultsResponse[index].permalink;
-                result.score = resultsResponse[index].score;
-                result.createdUtc = resultsResponse[index].createdUtc;
-                result.domain = resultsResponse[index].domain;
-                result.comments = resultsResponse[index].comments;
-                results.push(result);
-            }
+            if (!resultsResponse.length) {
+                dispatch(newGetNextResults(resultsResponse, nextUri, afterId));
+            } else {
+                const results = [];
+                for (let index in resultsResponse) {
+                    let result = {};
+                    result.id = resultsResponse[index].resultsId;
+                    result.subreddit = resultsResponse[index].subreddit;
+                    result.url = resultsResponse[index].url;
+                    result.title = resultsResponse[index].title;
+                    result.permalink = resultsResponse[index].permalink;
+                    result.score = resultsResponse[index].score;
+                    result.createdUtc = resultsResponse[index].createdUtc;
+                    result.domain = resultsResponse[index].domain;
+                    result.comments = resultsResponse[index].comments;
+                    results.push(result);
+                }
 
-            dispatch(resultsGetResultsSuccess(nextUri, afterId, results));
+                dispatch(resultsGetResultsSuccess(nextUri, afterId, results));
+            }
         })
         .catch(error => {
             dispatch(resultsGetResultsFail(error.response));
@@ -102,24 +106,28 @@ export const newGetNextResults = (results, nextUri, afterId) => {
         const uri = `/results/fetch/next`;
         axios.post(uri, postBody, {headers})
         .then(response => {
-            const resultsResponse = response.data.results;
-            const updatedResults = cloneDeep(results);
-            for (let index in resultsResponse) {
-                let result = {};
-                result.id = resultsResponse[index].resultsId;
-                result.subreddit = resultsResponse[index].subreddit;
-                result.url = resultsResponse[index].url;
-                result.title = resultsResponse[index].title;
-                result.permalink = resultsResponse[index].permalink;
-                result.score = resultsResponse[index].score;
-                result.createdUtc = resultsResponse[index].createdUtc;
-                result.domain = resultsResponse[index].domain;
-                result.comments = resultsResponse[index].comments;
-                updatedResults.push(result);
-            }
+            const newAfterId = response.data.afterId;
+            if (!response.data.results.length) {
+                dispatch(newGetNextResults(results, nextUri, newAfterId));
+            } else {
+                const resultsResponse = response.data.results;
+                const updatedResults = cloneDeep(results);
+                for (let index in resultsResponse) {
+                    let result = {};
+                    result.id = resultsResponse[index].resultsId;
+                    result.subreddit = resultsResponse[index].subreddit;
+                    result.url = resultsResponse[index].url;
+                    result.title = resultsResponse[index].title;
+                    result.permalink = resultsResponse[index].permalink;
+                    result.score = resultsResponse[index].score;
+                    result.createdUtc = resultsResponse[index].createdUtc;
+                    result.domain = resultsResponse[index].domain;
+                    result.comments = resultsResponse[index].comments;
+                    updatedResults.push(result);
+                }
 
-            const afterId = response.data.afterId;
-            dispatch(resultsGetNextResultsSuccess(afterId, updatedResults));
+                dispatch(resultsGetNextResultsSuccess(newAfterId, updatedResults));
+            }
         })
         .catch(error => {
             dispatch(resultsGetNextResultsFail(error.response));

--- a/src/store/actions/results/topResults.js
+++ b/src/store/actions/results/topResults.js
@@ -61,22 +61,26 @@ export const topGetResults = () => {
             const resultsResponse = response.data.results;
             const nextUri = response.data.nextUri;
             const afterId = response.data.afterId;
-            const results = [];
-            for (let index in resultsResponse) {
-                let result = {};
-                result.id = resultsResponse[index].resultsId;
-                result.subreddit = resultsResponse[index].subreddit;
-                result.url = resultsResponse[index].url;
-                result.title = resultsResponse[index].title;
-                result.permalink = resultsResponse[index].permalink;
-                result.score = resultsResponse[index].score;
-                result.createdUtc = resultsResponse[index].createdUtc;
-                result.domain = resultsResponse[index].domain;
-                result.comments = resultsResponse[index].comments;
-                results.push(result);
-            }
+            if (!resultsResponse.length) {
+                dispatch(topGetNextResults(resultsResponse, nextUri, afterId));
+            } else {
+                const results = [];
+                for (let index in resultsResponse) {
+                    let result = {};
+                    result.id = resultsResponse[index].resultsId;
+                    result.subreddit = resultsResponse[index].subreddit;
+                    result.url = resultsResponse[index].url;
+                    result.title = resultsResponse[index].title;
+                    result.permalink = resultsResponse[index].permalink;
+                    result.score = resultsResponse[index].score;
+                    result.createdUtc = resultsResponse[index].createdUtc;
+                    result.domain = resultsResponse[index].domain;
+                    result.comments = resultsResponse[index].comments;
+                    results.push(result);
+                }
 
-            dispatch(resultsGetResultsSuccess(nextUri, afterId, results));
+                dispatch(resultsGetResultsSuccess(nextUri, afterId, results));
+            }
         })
         .catch(error => {
             dispatch(resultsGetResultsFail(error.response));
@@ -102,24 +106,28 @@ export const topGetNextResults = (results, nextUri, afterId) => {
         const uri = `/results/fetch/next`;
         axios.post(uri, postBody, {headers})
         .then(response => {
-            const resultsResponse = response.data.results;
-            const updatedResults = cloneDeep(results);
-            for (let index in resultsResponse) {
-                let result = {};
-                result.id = resultsResponse[index].resultsId;
-                result.subreddit = resultsResponse[index].subreddit;
-                result.url = resultsResponse[index].url;
-                result.title = resultsResponse[index].title;
-                result.permalink = resultsResponse[index].permalink;
-                result.score = resultsResponse[index].score;
-                result.createdUtc = resultsResponse[index].createdUtc;
-                result.domain = resultsResponse[index].domain;
-                result.comments = resultsResponse[index].comments;
-                updatedResults.push(result);
-            }
+            const newAfterId = response.data.afterId;
+            if (!response.data.results.length) {
+                dispatch(topGetNextResults(results, nextUri, newAfterId));
+            } else {
+                const resultsResponse = response.data.results;
+                const updatedResults = cloneDeep(results);
+                for (let index in resultsResponse) {
+                    let result = {};
+                    result.id = resultsResponse[index].resultsId;
+                    result.subreddit = resultsResponse[index].subreddit;
+                    result.url = resultsResponse[index].url;
+                    result.title = resultsResponse[index].title;
+                    result.permalink = resultsResponse[index].permalink;
+                    result.score = resultsResponse[index].score;
+                    result.createdUtc = resultsResponse[index].createdUtc;
+                    result.domain = resultsResponse[index].domain;
+                    result.comments = resultsResponse[index].comments;
+                    updatedResults.push(result);
+                }
 
-            const afterId = response.data.afterId;
-            dispatch(resultsGetNextResultsSuccess(afterId, updatedResults));
+                dispatch(resultsGetNextResultsSuccess(newAfterId, updatedResults));
+            }
         })
         .catch(error => {
             dispatch(resultsGetNextResultsFail(error.response));


### PR DESCRIPTION
- Fixed a bug where if no Reddit results are found in `*GetResults()`
responses, then `*GetNextResults()` requests would not be called by
the `InfiniteScroll` component
- The solution is to handle empty results responses by always calling
`*GetNextResults()` in both `*GetResults()` and `*GetNextResults()`
functions
- Also updated the error message when no results are found at all